### PR TITLE
Fix header width

### DIFF
--- a/cody
+++ b/cody
@@ -221,7 +221,7 @@ print_header() {
     
     # Get terminal width
     local term_width=$(tput cols 2>/dev/null || echo 80)
-    local content_width=$((term_width > 80 ? 80 : term_width - 4))
+    local content_width=$term_width
     
     # Create top border
     local top_border="╭"


### PR DESCRIPTION
## Summary
- fill header to full terminal width

## Testing
- `bash -n cody`
- `shellcheck cody`

------
https://chatgpt.com/codex/tasks/task_e_6879107bda54832480b974e5b74d70c6